### PR TITLE
Adding check for httpoxy

### DIFF
--- a/rulelist.go
+++ b/rulelist.go
@@ -52,6 +52,7 @@ func newRulelist() rulelist {
 	rs.register("templates", rules.NewTemplateCheck)
 	rs.register("exec", rules.NewSubproc)
 	rs.register("errors", rules.NewNoErrorCheck)
+	rs.register("httpoxy", rules.NewHttpoxyTest)
 	return rs
 }
 

--- a/rules/httpoxy.go
+++ b/rules/httpoxy.go
@@ -1,0 +1,50 @@
+// (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"go/ast"
+	"regexp"
+
+	gas "github.com/HewlettPackard/gas/core"
+)
+
+// Looks for "import net/http/cgi"
+type HttpoxyTest struct {
+	gas.MetaData
+	pattern *regexp.Regexp
+}
+
+func (r *HttpoxyTest) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err error) {
+	if node, ok := n.(*ast.ImportSpec); ok {
+		if r.pattern.MatchString(node.Path.Value) {
+			return gas.NewIssue(c, n, r.What, r.Severity, r.Confidence), nil
+		}
+	}
+	return
+}
+
+func NewHttpoxyTest() (r gas.Rule, n ast.Node) {
+	r = &HttpoxyTest{
+		MetaData: gas.MetaData{
+			Severity:   gas.High,
+			Confidence: gas.Low,
+			What:       "Go code running under CGI is vulnerable to Httpoxy attack. (CVE-2016-5386)",
+		},
+		pattern: regexp.MustCompile("^\"net/http/cgi\"$"),
+	}
+	n = (*ast.ImportSpec)(nil)
+	return
+}

--- a/rules/httpoxy_test.go
+++ b/rules/httpoxy_test.go
@@ -1,0 +1,37 @@
+// (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
+)
+
+func TestHttpoxy(t *testing.T) {
+	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer.AddRule(NewHttpoxyTest())
+
+	issues := gasTestRunner(`
+		package main
+	        import (
+                	"log"
+                	"net/http/cgi"
+        	)
+		func main() {
+		}`, analyzer)
+
+	checkTestResults(t, issues, 1, "Go code running under CGI is vulnerable to Httpoxy attack.")
+}


### PR DESCRIPTION
Go code running under CGI is vulnerable to httpoxy attack. See
https://httpoxy.org/ this checks for an import of net/http/cgi
that might indicate code may be run under CGI.

closes #1