### PR TITLE
Make sure -fmt json produces valid output

### DIFF
--- a/output/formatter.go
+++ b/output/formatter.go
@@ -45,12 +45,12 @@ Summary:
 `
 
 var json = `{
-        "metrics": [
-            Files: {{.Stats.NumFiles}},
-            Lines: {{.Stats.NumLines}},
-            Nosec: {{.Stats.NumNosec}},
-            Issues: {{.Stats.NumFound}}],
-
+        "metrics": {
+            "files": {{.Stats.NumFiles}},
+            "lines": {{.Stats.NumLines}},
+            "nosec": {{.Stats.NumNosec}},
+            "issues": {{.Stats.NumFound}}
+        },
         "issues": [
         {{ range $index, $issue := .Issues }}{{ if $index }}, {{ end }}{
           "file": "{{ $issue.File }}",


### PR DESCRIPTION
r: @gcmurphy 

This makes sure that `-fmt json` produces output that is a valid JSON document. 

Before:
```
$ gas -fmt json main.go | head -n6
{
        "metrics": [
            Files: 1,
            Lines: 508,
            Nosec: 0,
            Issues: 1],
```

After:
```
$ gas -fmt json main.go | head -n7
{
        "metrics": {
            "files": 1,
            "lines": 508,
            "nosec": 0,
            "issues": 1
        },
```

In the future, would probably be better to serialize a struct with `encoding/json` instead of using templates. 