### PR TITLE
Use encoding/json for -fmt json output

### DIFF
--- a/core/analyzer.go
+++ b/core/analyzer.go
@@ -40,10 +40,10 @@ type Rule interface {
 type RuleSet map[reflect.Type][]Rule
 
 type Metrics struct {
-	NumFiles int
-	NumLines int
-	NumNosec int
-	NumFound int
+	NumFiles int `json:"files"`
+	NumLines int `json:"lines"`
+	NumNosec int `json:"nosec"`
+	NumFound int `json:"found"`
 }
 
 type Analyzer struct {
@@ -51,8 +51,8 @@ type Analyzer struct {
 	ruleset     RuleSet
 	context     Context
 	logger      *log.Logger
-	Issues      []Issue
-	Stats       Metrics
+	Issues      []Issue `json:"issues"`
+	Stats       Metrics `json:"metrics"`
 }
 
 func NewAnalyzer(annotations bool, logger *log.Logger) Analyzer {

--- a/core/issue.go
+++ b/core/issue.go
@@ -14,6 +14,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"go/ast"
 	"os"
@@ -28,18 +29,22 @@ const (
 )
 
 type Issue struct {
-	Severity   Score
-	Confidence Score
-	What       string
-	File       string
-	Code       string
-	Line       int
+	Severity   Score  `json:"severity"`
+	Confidence Score  `json:"confidence"`
+	What       string `json:"details"`
+	File       string `json:"file"`
+	Code       string `json:"code"`
+	Line       int    `json:"line"`
 }
 
 type MetaData struct {
 	Severity   Score
 	Confidence Score
 	What       string
+}
+
+func (c Score) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
 }
 
 func (c Score) String() string {


### PR DESCRIPTION
r: @gcmurphy 

Fixes bug #12, so escaping works now:
```
cs gas-test master $ gas -fmt json main.go
{
	"issues": [
		{
			"severity": "HIGH",
			"confidence": "LOW",
			"details": "Potential hardcoded credentials",
			"file": "main.go",
			"code": "password := \"repro for escaping bug \u003c \u003e \u0026 ;\"",
			"line": 4
		}
	],
	"metrics": {
		"files": 1,
		"lines": 5,
		"nosec": 0,
		"found": 1
	}
}
```

Parses correctly (using `jq` as example):
```
cs gas-test master $ gas -fmt json main.go | jq .
{
  "issues": [
    {
      "severity": "HIGH",
      "confidence": "LOW",
      "details": "Potential hardcoded credentials",
      "file": "main.go",
      "code": "password := \"repro for escaping bug < > & ;\"",
      "line": 4
    }
  ],
  "metrics": {
    "files": 1,
    "lines": 5,
    "nosec": 0,
    "found": 1
  }
}
```