### PR TITLE
Smarter hard-coded credentials check

### DIFF
--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -15,9 +15,10 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"go/ast"
 	"regexp"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 type CredsAssign struct {
@@ -30,8 +31,11 @@ func (r *CredsAssign) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err erro
 		for _, i := range node.Lhs {
 			if ident, ok := i.(*ast.Ident); ok {
 				if r.pattern.MatchString(ident.Name) {
-					gi = gas.NewIssue(c, n, r.What, r.Severity, r.Confidence)
-					break
+					for _, e := range node.Rhs {
+						if _, ok := e.(*ast.BasicLit); ok {
+							return gas.NewIssue(c, n, r.What, r.Severity, r.Confidence), nil
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
@gcmurphy @callidus 
Check right-hand side expr for literals when looking for hard-coded credentials.

Example file:
```Go
package main

func main() {
  passwordBad := "password"
  passwordOk := getPassword()
}
```

With these changes, the first line in `main` will still warn, but the second line will now be fine. Previously both lines would produce a warning.

Anecdotally (based on running this on Square's internal Go code base) the hard-coded credentials check almost always yields false positives, since it's a common pattern to read a secret from e.g. a file and then load it into a variable like "password" or "token" or such.