### PR TITLE
Fixing annotations

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 // #nosec flag
-var flagNoSec = flag.Bool("nosec", false, "Ignores #nosec comments when set")
+var flagIgnoreNoSec = flag.Bool("nosec", false, "Ignores #nosec comments when set")
 
 // format output
 var flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, csv of text")
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	// Setup analyzer
-	analyzer := gas.NewAnalyzer(*flagNoSec, logger)
+	analyzer := gas.NewAnalyzer(*flagIgnoreNoSec, logger)
 	if !rules.overwritten {
 		rules.useDefaults()
 	}

--- a/rules/nosec_test.go
+++ b/rules/nosec_test.go
@@ -1,0 +1,60 @@
+// (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
+)
+
+func TestNosec(t *testing.T) {
+	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer.AddRule(NewSubproc())
+
+	issues := gasTestRunner(
+		`package main
+
+    import (
+    	"fmt"
+    )
+
+    func main() {
+      cmd := exec.Command("sh", "-c", config.Command) // #nosec
+    }`, analyzer)
+
+	checkTestResults(t, issues, 0, "None")
+}
+
+func TestNosecBlock(t *testing.T) {
+	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer.AddRule(NewSubproc())
+
+	issues := gasTestRunner(
+		`package main
+
+    import (
+    	"fmt"
+    )
+
+    func main() {
+			// #nosec
+			if true {
+      	cmd := exec.Command("sh", "-c", config.Command)
+			}
+    }`, analyzer)
+
+	checkTestResults(t, issues, 0, "None")
+}


### PR DESCRIPTION
The logic around annotations (nosec) was broken, meaning they were
ignored by default and would not skip sub-blocks. This fixes the
problem and also adds a test to make sure it wont be broken in the
future. Closes #25