### PR TITLE
Fix os.IsExist() condition in filelist.Contains()

### DIFF
--- a/filelist.go
+++ b/filelist.go
@@ -59,7 +59,7 @@ func (f *filelist) Contains(pathname string) bool {
 
 		// Finally try absolute path
 		st, e := os.Stat(rel)
-		if !os.IsNotExist(e) && st.IsDir() && strings.HasPrefix(abs, rel) {
+		if os.IsExist(e) && st.IsDir() && strings.HasPrefix(abs, rel) {
 			return true
 		}
 


### PR DESCRIPTION
It is a little tricky that !os.IsNotExist(e) is not equal to os.IsExist(e) while the program is running on Windows.
[https://golang.org/src/os/error_windows.go](error_windows.go)

The default excluded filelist is "*_test.go" and the path name is invalid when call os.Stat() on Windows.
Take the following code for example:
```
package main

import (
    "log"
    "os"
)

func main() {
    st, e := os.Stat("*_test.go")
    if e != nil {
        log.Println(e)
    }
    log.Println( "!os.IsNotExist:", !os.IsNotExist(e) )
    log.Println( "os.IsExist:", os.IsExist(e) )
    log.Println( "Status:", st )
}
```` 

The result on Linux:
```` 
2016/07/29 22:52:55 stat *_test.go: no such file or directory
2016/07/29 22:52:55 !os.IsNotExist: false
2016/07/29 22:52:55 os.IsExist: false
2016/07/29 22:52:55 Status: <nil>
```` 

The result on Windows:
```` 
2016/07/29 22:53:10 GetFileAttributesEx *_test.go: The filename, directory name, or volume label syntax is incorrect.
2016/07/29 22:53:10 !os.IsNotExist: true
2016/07/29 22:53:10 os.IsExist: false
2016/07/29 22:53:10 Status: <nil>
```` 

Line 62 in filelist.go would cause program panic when the program is running on Windows because  !os.IsNotExist(e) is true and st is nil.