### PR TITLE
Fix incorrect regexp matches

### DIFF
--- a/rules/bind.go
+++ b/rules/bind.go
@@ -40,7 +40,7 @@ func (r *BindsToAllNetworkInterfaces) Match(n ast.Node, c *gas.Context) (gi *gas
 
 func NewBindsToAllNetworkInterfaces() (r gas.Rule, n ast.Node) {
 	r = &BindsToAllNetworkInterfaces{
-		call:    regexp.MustCompile(`^net.Listen$`),
+		call:    regexp.MustCompile(`^net\.Listen$`),
 		pattern: regexp.MustCompile(`^(0.0.0.0|:).*$`),
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,

--- a/rules/fileperms.go
+++ b/rules/fileperms.go
@@ -39,7 +39,7 @@ func (r *FilePermissions) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) 
 func NewChmodPerms() (r gas.Rule, n ast.Node) {
 	mode := 0600
 	r = &FilePermissions{
-		pattern: regexp.MustCompile(`^os.Chmod$`),
+		pattern: regexp.MustCompile(`^os\.Chmod$`),
 		mode:    (int64)(mode),
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,
@@ -54,7 +54,7 @@ func NewChmodPerms() (r gas.Rule, n ast.Node) {
 func NewMkdirPerms() (r gas.Rule, n ast.Node) {
 	mode := 0700
 	r = &FilePermissions{
-		pattern: regexp.MustCompile(`^(os.Mkdir|os.MkdirAll)$`),
+		pattern: regexp.MustCompile(`^(os\.Mkdir|os\.MkdirAll)$`),
 		mode:    (int64)(mode),
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,

--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -45,7 +45,7 @@ func (r *CredsAssign) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err erro
 
 func NewHardcodedCredentials() (r gas.Rule, n ast.Node) {
 	r = &CredsAssign{
-		pattern: regexp.MustCompile("(?i)passwd|pass|password|pwd|secret|token"),
+		pattern: regexp.MustCompile(`(?i)passwd|pass|password|pwd|secret|token`),
 		MetaData: gas.MetaData{
 			What:       "Potential hardcoded credentials",
 			Confidence: gas.Low,

--- a/rules/httpoxy.go
+++ b/rules/httpoxy.go
@@ -43,7 +43,7 @@ func NewHttpoxyTest() (r gas.Rule, n ast.Node) {
 			Confidence: gas.Low,
 			What:       "Go code running under CGI is vulnerable to Httpoxy attack. (CVE-2016-5386)",
 		},
-		pattern: regexp.MustCompile("^\"net/http/cgi\"$"),
+		pattern: regexp.MustCompile(`^"net/http/cgi"$`),
 	}
 	n = (*ast.ImportSpec)(nil)
 	return

--- a/rules/rand.go
+++ b/rules/rand.go
@@ -41,7 +41,7 @@ func (w *WeakRand) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) {
 
 func NewWeakRandCheck() (r gas.Rule, n ast.Node) {
 	r = &WeakRand{
-		pattern:     regexp.MustCompile(`^rand.Read$`),
+		pattern:     regexp.MustCompile(`^rand\.Read$`),
 		packageName: "rand",
 		packagePath: "math/rand",
 		MetaData: gas.MetaData{

--- a/rules/rsa.go
+++ b/rules/rsa.go
@@ -40,7 +40,7 @@ func (w *WeakKeyStrength) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) 
 func NewWeakKeyStrength() (r gas.Rule, n ast.Node) {
 	bits := 2048
 	r = &WeakKeyStrength{
-		pattern: regexp.MustCompile(`^rsa.GenerateKey$`),
+		pattern: regexp.MustCompile(`^rsa\.GenerateKey$`),
 		bits:    bits,
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -59,7 +59,7 @@ func (s *SqlStrConcat) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) {
 func NewSqlStrConcat() (r gas.Rule, n ast.Node) {
 	r = &SqlStrConcat{
 		SqlStatement: SqlStatement{
-			pattern: regexp.MustCompile("(?)(SELECT|DELETE|INSERT|UPDATE|INTO|FROM|WHERE) "),
+			pattern: regexp.MustCompile(`(?)(SELECT|DELETE|INSERT|UPDATE|INTO|FROM|WHERE) `),
 			MetaData: gas.MetaData{
 				Severity:   gas.Medium,
 				Confidence: gas.High,
@@ -88,7 +88,7 @@ func (s *SqlStrFormat) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err err
 
 func NewSqlStrFormat() (r gas.Rule, n ast.Node) {
 	r = &SqlStrFormat{
-		call: regexp.MustCompile("^fmt.Sprintf$"),
+		call: regexp.MustCompile(`^fmt\.Sprintf$`),
 		SqlStatement: SqlStatement{
 			pattern: regexp.MustCompile("(?)(SELECT|DELETE|INSERT|UPDATE|INTO|FROM|WHERE) "),
 			MetaData: gas.MetaData{

--- a/rules/tempfiles.go
+++ b/rules/tempfiles.go
@@ -37,8 +37,8 @@ func (t *BadTempFile) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err erro
 
 func NewBadTempFile() (r gas.Rule, n ast.Node) {
 	r = &BadTempFile{
-		call: regexp.MustCompile("ioutil.WriteFile|os.Create"),
-		args: regexp.MustCompile("^/tmp/.*$|^/var/tmp/.*$"),
+		call: regexp.MustCompile(`ioutil\.WriteFile|os\.Create`),
+		args: regexp.MustCompile(`^/tmp/.*$|^/var/tmp/.*$`),
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,
 			Confidence: gas.High,

--- a/rules/templates.go
+++ b/rules/templates.go
@@ -38,7 +38,7 @@ func (t *TemplateCheck) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err er
 
 func NewTemplateCheck() (r gas.Rule, n ast.Node) {
 	r = &TemplateCheck{
-		call: regexp.MustCompile("^template.(HTML|JS|URL)$"),
+		call: regexp.MustCompile(`^template\.(HTML|JS|URL)$`),
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,
 			Confidence: gas.Low,

--- a/rules/tls.go
+++ b/rules/tls.go
@@ -112,7 +112,7 @@ func (t *InsecureConfigTLS) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, er
 func NewModernTlsCheck() (r gas.Rule, n ast.Node) {
 	// https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
 	r = &InsecureConfigTLS{
-		pattern:    regexp.MustCompile("^tls.Config$"),
+		pattern:    regexp.MustCompile(`^tls\.Config$`),
 		MinVersion: 0x0303, // TLS 1.2 only
 		MaxVersion: 0x0303,
 		goodCiphers: []string{
@@ -129,7 +129,7 @@ func NewModernTlsCheck() (r gas.Rule, n ast.Node) {
 func NewIntermediateTlsCheck() (r gas.Rule, n ast.Node) {
 	// https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28default.29
 	r = &InsecureConfigTLS{
-		pattern:    regexp.MustCompile("^tls.Config$"),
+		pattern:    regexp.MustCompile(`^tls\.Config$`),
 		MinVersion: 0x0301, // TLS 1.2, 1.1, 1.0
 		MaxVersion: 0x0303,
 		goodCiphers: []string{
@@ -157,7 +157,7 @@ func NewIntermediateTlsCheck() (r gas.Rule, n ast.Node) {
 func NewCompatTlsCheck() (r gas.Rule, n ast.Node) {
 	// https://wiki.mozilla.org/Security/Server_Side_TLS#Old_compatibility_.28default.29
 	r = &InsecureConfigTLS{
-		pattern:    regexp.MustCompile("^tls.Config$"),
+		pattern:    regexp.MustCompile(`^tls\.Config$`),
 		MinVersion: 0x0301, // TLS 1.2, 1.1, 1.0
 		MaxVersion: 0x0303,
 		goodCiphers: []string{

--- a/rules/unsafe.go
+++ b/rules/unsafe.go
@@ -34,7 +34,7 @@ func (r *UsingUnsafe) Match(n ast.Node, c *gas.Context) (gi *gas.Issue, err erro
 
 func NewUsingUnsafe() (r gas.Rule, n ast.Node) {
 	r = &UsingUnsafe{
-		pattern: regexp.MustCompile("unsafe.*"),
+		pattern: regexp.MustCompile(`unsafe.*`),
 		MetaData: gas.MetaData{
 			What:       "Use of unsafe calls should be audited",
 			Severity:   gas.Low,

--- a/rules/weakcrypto.go
+++ b/rules/weakcrypto.go
@@ -40,7 +40,7 @@ func (r *ImportsWeakCryptography) Match(n ast.Node, c *gas.Context) (gi *gas.Iss
 // Imports crypto/md5, crypto/des crypto/rc4
 func NewImportsWeakCryptography() (r gas.Rule, n ast.Node) {
 	r = &ImportsWeakCryptography{
-		pattern: regexp.MustCompile("crypto/md5|crypto/des|crypto/rc4"),
+		pattern: regexp.MustCompile(`crypto/md5|crypto/des|crypto/rc4`),
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,
 			Confidence: gas.High,
@@ -66,7 +66,7 @@ func (r *UsesWeakCryptography) Match(n ast.Node, c *gas.Context) (*gas.Issue, er
 // Uses des.* md5.* or rc4.*
 func NewUsesWeakCryptography() (r gas.Rule, n ast.Node) {
 	r = &UsesWeakCryptography{
-		pattern: regexp.MustCompile("des.NewCipher|des.NewTripleDESCipher|md5.New|md5.Sum|rc4.NewCipher"),
+		pattern: regexp.MustCompile(`des\.NewCipher|des\.NewTripleDESCipher|md5\.New|md5\.Sum|rc4\.NewCipher`),
 		MetaData: gas.MetaData{
 			Severity:   gas.Medium,
 			Confidence: gas.High,


### PR DESCRIPTION
There are some cases where the '.' character would also match any
character and could lead to incorrect results. For example the
regular expression -  `^ioutils.WriteFile$' would match
ioutils.WriteFile, but also ioutils_WriteFile.

Additionally made sure that all regexp were declared using raw
strings to avoid any unnecesary string escaping that potentially
make the regexp difficult to read.