### PR TITLE
Adding a config block to the analyzer, parsed from JSON

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ var flagFormat = flag.String("fmt", "text", "Set output format. Valid options ar
 // output file
 var flagOutput = flag.String("out", "", "Set output file for results")
 
+var flagConfig = flag.String("conf", "", "Path to optional config file")
+
 var usageText = `
 GAS - Go AST Scanner
 
@@ -99,7 +101,7 @@ func main() {
 	}
 
 	// Setup analyzer
-	analyzer := gas.NewAnalyzer(*flagIgnoreNoSec, logger)
+	analyzer := gas.NewAnalyzer(*flagIgnoreNoSec, flagConfig, logger)
 	if !rules.overwritten {
 		rules.useDefaults()
 	}

--- a/rules/bind_test.go
+++ b/rules/bind_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestBind0000(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewBindsToAllNetworkInterfaces())
 
 	issues := gasTestRunner(`
@@ -41,7 +42,7 @@ func TestBind0000(t *testing.T) {
 }
 
 func TestBindEmptyHost(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewBindsToAllNetworkInterfaces())
 
 	issues := gasTestRunner(`

--- a/rules/errors_test.go
+++ b/rules/errors_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestErrorsMulti(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewNoErrorCheck())
 
 	issues := gasTestRunner(
@@ -43,7 +43,7 @@ func TestErrorsMulti(t *testing.T) {
 }
 
 func TestErrorsSingle(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewNoErrorCheck())
 
 	issues := gasTestRunner(
@@ -65,7 +65,7 @@ func TestErrorsSingle(t *testing.T) {
 }
 
 func TestErrorsGood(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewNoErrorCheck())
 
 	issues := gasTestRunner(

--- a/rules/fileperms_test.go
+++ b/rules/fileperms_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestChmod(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewChmodPerms())
 
 	issues := gasTestRunner(`
@@ -35,7 +36,7 @@ func TestChmod(t *testing.T) {
 }
 
 func TestMkdir(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewMkdirPerms())
 
 	issues := gasTestRunner(`

--- a/rules/hardcoded_credentials_test.go
+++ b/rules/hardcoded_credentials_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestHardcoded(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewHardcodedCredentials())
 
 	issues := gasTestRunner(

--- a/rules/httpoxy_test.go
+++ b/rules/httpoxy_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestHttpoxy(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewHttpoxyTest())
 
 	issues := gasTestRunner(`

--- a/rules/nosec_test.go
+++ b/rules/nosec_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestNosec(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(
@@ -39,7 +39,7 @@ func TestNosec(t *testing.T) {
 }
 
 func TestNosecBlock(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(

--- a/rules/rand_test.go
+++ b/rules/rand_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestRandOk(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewWeakRandCheck())
 
 	issues := gasTestRunner(
@@ -38,7 +38,7 @@ func TestRandOk(t *testing.T) {
 }
 
 func TestRandBad(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewWeakRandCheck())
 
 	issues := gasTestRunner(

--- a/rules/rsa_test.go
+++ b/rules/rsa_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestRSAKeys(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewWeakKeyStrength())
 
 	issues := gasTestRunner(

--- a/rules/sql_test.go
+++ b/rules/sql_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestSQLInjectionViaConcatenation(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 
 	source := `
@@ -48,7 +48,7 @@ func TestSQLInjectionViaConcatenation(t *testing.T) {
 }
 
 func TestSQLInjectionViaIntepolation(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSqlStrFormat())
 
 	source := `
@@ -77,7 +77,7 @@ func TestSQLInjectionViaIntepolation(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveA(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 
@@ -112,7 +112,7 @@ func TestSQLInjectionFalsePositiveA(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveB(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 
@@ -147,7 +147,7 @@ func TestSQLInjectionFalsePositiveB(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveC(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 
@@ -182,7 +182,7 @@ func TestSQLInjectionFalsePositiveC(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveD(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 

--- a/rules/subproc_test.go
+++ b/rules/subproc_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestSubprocess(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(`
@@ -46,7 +47,7 @@ func TestSubprocess(t *testing.T) {
 }
 
 func TestSubprocessVar(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(`
@@ -73,7 +74,7 @@ func TestSubprocessVar(t *testing.T) {
 }
 
 func TestSubprocessPath(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(`

--- a/rules/tempfiles_test.go
+++ b/rules/tempfiles_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestTempfiles(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewBadTempFile())
 
 	source := `

--- a/rules/templates_test.go
+++ b/rules/templates_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestTemplateCheckSafe(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `
@@ -47,7 +48,7 @@ func TestTemplateCheckSafe(t *testing.T) {
 }
 
 func TestTemplateCheckBadHTML(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `
@@ -75,7 +76,7 @@ func TestTemplateCheckBadHTML(t *testing.T) {
 }
 
 func TestTemplateCheckBadJS(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `
@@ -103,7 +104,7 @@ func TestTemplateCheckBadJS(t *testing.T) {
 }
 
 func TestTemplateCheckBadURL(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `

--- a/rules/tls_test.go
+++ b/rules/tls_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestInsecureSkipVerify(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`
@@ -49,7 +49,7 @@ func TestInsecureSkipVerify(t *testing.T) {
 }
 
 func TestInsecureMinVersion(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`
@@ -77,7 +77,7 @@ func TestInsecureMinVersion(t *testing.T) {
 }
 
 func TestInsecureMaxVersion(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`
@@ -105,7 +105,7 @@ func TestInsecureMaxVersion(t *testing.T) {
 }
 
 func TestInsecureCipherSuite(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`

--- a/rules/unsafe_test.go
+++ b/rules/unsafe_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestUnsafe(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewUsingUnsafe())
 
 	issues := gasTestRunner(`

--- a/rules/weakcrypto_test.go
+++ b/rules/weakcrypto_test.go
@@ -15,12 +15,13 @@
 package rules
 
 import (
-	gas "github.com/HewlettPackard/gas/core"
 	"testing"
+
+	gas "github.com/HewlettPackard/gas/core"
 )
 
 func TestMD5(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewImportsWeakCryptography())
 	analyzer.AddRule(NewUsesWeakCryptography())
 
@@ -41,7 +42,7 @@ func TestMD5(t *testing.T) {
 }
 
 func TestDES(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewImportsWeakCryptography())
 	analyzer.AddRule(NewUsesWeakCryptography())
 
@@ -80,7 +81,7 @@ func TestDES(t *testing.T) {
 }
 
 func TestRC4(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil)
+	analyzer := gas.NewAnalyzer(false, nil, nil)
 	analyzer.AddRule(NewImportsWeakCryptography())
 	analyzer.AddRule(NewUsesWeakCryptography())
 


### PR DESCRIPTION
A CLI option can now be given to tell GAS it should parse data
from a JSON file. Fatal errors are given if the file is not
readable or is not valid JSON.