### PR TITLE
Configuration

### DIFF
--- a/core/analyzer.go
+++ b/core/analyzer.go
@@ -15,13 +15,11 @@
 package core
 
 import (
-	"encoding/json"
 	"go/ast"
 	"go/importer"
 	"go/parser"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -59,27 +57,19 @@ type Analyzer struct {
 	Stats       Metrics `json:"metrics"`
 }
 
-func NewAnalyzer(ignoreNosec bool, conf *string, logger *log.Logger) Analyzer {
+func NewAnalyzer(conf map[string]interface{}, logger *log.Logger) Analyzer {
 	if logger == nil {
 		logger = log.New(os.Stdout, "[gas]", 0)
 	}
 	a := Analyzer{
-		ignoreNosec: ignoreNosec,
+		ignoreNosec: conf["ignoreNosec"].(bool),
 		ruleset:     make(RuleSet),
 		Issues:      make([]Issue, 0),
 		context:     Context{token.NewFileSet(), nil, nil, nil, nil, nil},
 		logger:      logger,
 	}
 
-	if conf != nil && *conf != "" { // if we have a config
-		if data, err := ioutil.ReadFile(*conf); err == nil {
-			if err := json.Unmarshal(data, &(a.context.Config)); err != nil {
-				logger.Fatal("Could not parse JSON config: ", *conf, ": ", err)
-			}
-		} else {
-			logger.Fatal("Could not read config file: ", *conf)
-		}
-	}
+	// TODO(tkelsey): use the inc/exc lists
 
 	return a
 }

--- a/rules/bind_test.go
+++ b/rules/bind_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestBind0000(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewBindsToAllNetworkInterfaces())
 
 	issues := gasTestRunner(`
@@ -42,7 +43,8 @@ func TestBind0000(t *testing.T) {
 }
 
 func TestBindEmptyHost(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewBindsToAllNetworkInterfaces())
 
 	issues := gasTestRunner(`

--- a/rules/errors_test.go
+++ b/rules/errors_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestErrorsMulti(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewNoErrorCheck())
 
 	issues := gasTestRunner(
@@ -43,7 +44,8 @@ func TestErrorsMulti(t *testing.T) {
 }
 
 func TestErrorsSingle(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewNoErrorCheck())
 
 	issues := gasTestRunner(
@@ -65,7 +67,8 @@ func TestErrorsSingle(t *testing.T) {
 }
 
 func TestErrorsGood(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewNoErrorCheck())
 
 	issues := gasTestRunner(

--- a/rules/fileperms_test.go
+++ b/rules/fileperms_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestChmod(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewChmodPerms())
 
 	issues := gasTestRunner(`
@@ -36,7 +37,8 @@ func TestChmod(t *testing.T) {
 }
 
 func TestMkdir(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewMkdirPerms())
 
 	issues := gasTestRunner(`

--- a/rules/hardcoded_credentials_test.go
+++ b/rules/hardcoded_credentials_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestHardcoded(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewHardcodedCredentials())
 
 	issues := gasTestRunner(

--- a/rules/httpoxy_test.go
+++ b/rules/httpoxy_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestHttpoxy(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewBlacklistImports())
 
 	issues := gasTestRunner(`

--- a/rules/nosec_test.go
+++ b/rules/nosec_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestNosec(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(
@@ -39,7 +40,8 @@ func TestNosec(t *testing.T) {
 }
 
 func TestNosecBlock(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(
@@ -57,4 +59,23 @@ func TestNosecBlock(t *testing.T) {
     }`, analyzer)
 
 	checkTestResults(t, issues, 0, "None")
+}
+
+func TestNosecIgnore(t *testing.T) {
+	config := map[string]interface{}{"ignoreNosec": true}
+	analyzer := gas.NewAnalyzer(config, nil)
+	analyzer.AddRule(NewSubproc())
+
+	issues := gasTestRunner(
+		`package main
+
+    import (
+    	"fmt"
+    )
+
+    func main() {
+      cmd := exec.Command("sh", "-c", config.Command) // #nosec
+    }`, analyzer)
+
+	checkTestResults(t, issues, 1, "Subprocess launching with variable.")
 }

--- a/rules/rand_test.go
+++ b/rules/rand_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestRandOk(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewWeakRandCheck())
 
 	issues := gasTestRunner(
@@ -38,7 +39,8 @@ func TestRandOk(t *testing.T) {
 }
 
 func TestRandBad(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewWeakRandCheck())
 
 	issues := gasTestRunner(

--- a/rules/rsa_test.go
+++ b/rules/rsa_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestRSAKeys(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewWeakKeyStrength())
 
 	issues := gasTestRunner(

--- a/rules/sql_test.go
+++ b/rules/sql_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestSQLInjectionViaConcatenation(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 
 	source := `
@@ -48,7 +49,8 @@ func TestSQLInjectionViaConcatenation(t *testing.T) {
 }
 
 func TestSQLInjectionViaIntepolation(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSqlStrFormat())
 
 	source := `
@@ -77,7 +79,8 @@ func TestSQLInjectionViaIntepolation(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveA(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 
@@ -112,7 +115,8 @@ func TestSQLInjectionFalsePositiveA(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveB(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 
@@ -147,7 +151,8 @@ func TestSQLInjectionFalsePositiveB(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveC(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 
@@ -182,7 +187,8 @@ func TestSQLInjectionFalsePositiveC(t *testing.T) {
 }
 
 func TestSQLInjectionFalsePositiveD(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSqlStrConcat())
 	analyzer.AddRule(NewSqlStrFormat())
 

--- a/rules/subproc_test.go
+++ b/rules/subproc_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestSubprocess(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(`
@@ -48,7 +49,8 @@ func TestSubprocess(t *testing.T) {
 }
 
 func TestSubprocessVar(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(`
@@ -75,7 +77,8 @@ func TestSubprocessVar(t *testing.T) {
 }
 
 func TestSubprocessPath(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(`
@@ -101,7 +104,8 @@ func TestSubprocessPath(t *testing.T) {
 }
 
 func TestSubprocessSyscall(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewSubproc())
 
 	issues := gasTestRunner(`

--- a/rules/tempfiles_test.go
+++ b/rules/tempfiles_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestTempfiles(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewBadTempFile())
 
 	source := `

--- a/rules/templates_test.go
+++ b/rules/templates_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestTemplateCheckSafe(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `
@@ -48,7 +49,8 @@ func TestTemplateCheckSafe(t *testing.T) {
 }
 
 func TestTemplateCheckBadHTML(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `
@@ -76,7 +78,8 @@ func TestTemplateCheckBadHTML(t *testing.T) {
 }
 
 func TestTemplateCheckBadJS(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `
@@ -104,7 +107,8 @@ func TestTemplateCheckBadJS(t *testing.T) {
 }
 
 func TestTemplateCheckBadURL(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewTemplateCheck())
 
 	source := `

--- a/rules/tls_test.go
+++ b/rules/tls_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestInsecureSkipVerify(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`
@@ -49,7 +50,8 @@ func TestInsecureSkipVerify(t *testing.T) {
 }
 
 func TestInsecureMinVersion(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`
@@ -77,7 +79,8 @@ func TestInsecureMinVersion(t *testing.T) {
 }
 
 func TestInsecureMaxVersion(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`
@@ -105,7 +108,8 @@ func TestInsecureMaxVersion(t *testing.T) {
 }
 
 func TestInsecureCipherSuite(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewModernTlsCheck())
 
 	issues := gasTestRunner(`

--- a/rules/unsafe_test.go
+++ b/rules/unsafe_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestUnsafe(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewUsingUnsafe())
 
 	issues := gasTestRunner(`

--- a/rules/weakcrypto_test.go
+++ b/rules/weakcrypto_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestMD5(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewBlacklistImports())
 	analyzer.AddRule(NewUsesWeakCryptography())
 
@@ -42,7 +43,8 @@ func TestMD5(t *testing.T) {
 }
 
 func TestDES(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewBlacklistImports())
 	analyzer.AddRule(NewUsesWeakCryptography())
 
@@ -81,7 +83,8 @@ func TestDES(t *testing.T) {
 }
 
 func TestRC4(t *testing.T) {
-	analyzer := gas.NewAnalyzer(false, nil, nil)
+	config := map[string]interface{}{"ignoreNosec": false}
+	analyzer := gas.NewAnalyzer(config, nil)
 	analyzer.AddRule(NewBlacklistImports())
 	analyzer.AddRule(NewUsesWeakCryptography())
 


### PR DESCRIPTION
This re-works the way that CLI options are passed through to the
analyzer so that they can act as overrides for config options. If
not given on the CLI, options will come from a config file. If no
file is used then a default value is chosen.

Two lists are also populated with tests to include or exclude.
These lists are not used for now but will eventually replace the
way we select test to run in a future patch to follow.  NOTE that
the "exclude" CLI option has been repurposed to mean
excluded rules, a new "skip" option has been added to replace
the old behaviour.
