### PR TITLE
prefix patterns with **/ to match subdirectories

### DIFF
--- a/filelist.go
+++ b/filelist.go
@@ -57,6 +57,11 @@ func (f *filelist) Contains(pathname string) bool {
 			return true
 		}
 
+		// match file suffixes ie. *_test.go
+		if matched, _ := filepath.Match(filepath.Join("**", pattern), pathname); matched {
+			return true
+		}
+
 		// Finally try absolute path
 		st, e := os.Stat(rel)
 		if os.IsExist(e) && st.IsDir() && strings.HasPrefix(abs, rel) {


### PR DESCRIPTION
fixes #45 

filepath.Match() requires the entire path is matched, prefixing ** allows `*_test.go` to work in multiple packages.